### PR TITLE
Set pdf worker using GlobalWokerOptions.workerSrc in pdf.js

### DIFF
--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -1,4 +1,6 @@
 const pdfjs = require('pdfjs-dist/legacy/build/pdf')
+pdfjs.GlobalWorkerOptions.workerSrc = `pdfjs-dist/legacy/build/pdf.worker`;
+
 const { findPageNumbers, findFirstPage, removePageNumber } = require('../../lib/util/page-number-functions')
 const TextItem = require('../models/TextItem')
 const Page = require('../models/Page')


### PR DESCRIPTION
## Problem

Error: `Setting up fake worker failed: \"No \"GlobalWorkerOptions.workerSrc\" specified.\"."`

Closes #64 

## Solution

Setting the workerSrc in `lib/util/pdf.js`
