### PR TITLE
Fix fetchStandardFontData warning

### DIFF
--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -13,7 +13,12 @@ exports.parse = async function parse (docOptions, callbacks) {
     documentParsed: NO_OP,
     ...(callbacks || {}),
   }
-  const pdfDocument = await pdfjs.getDocument(docOptions).promise
+  fontDataPath = __dirname + '/../../../../../node_modules/pdfjs-dist/standard_fonts/'
+  const pdfDocument = await pdfjs.getDocument(
+    {
+      data: docOptions,
+      standardFontDataUrl: fontDataPath
+    }).promise
   const metadata = await pdfDocument.getMetadata()
   metadataParsed(metadata)
 

--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const pdfjs = require('pdfjs-dist/legacy/build/pdf')
 const { findPageNumbers, findFirstPage, removePageNumber } = require('../../lib/util/page-number-functions')
 const TextItem = require('../models/TextItem')
@@ -13,7 +14,7 @@ exports.parse = async function parse (docOptions, callbacks) {
     documentParsed: NO_OP,
     ...(callbacks || {}),
   }
-  fontDataPath = __dirname + '/../../../../../node_modules/pdfjs-dist/standard_fonts/'
+  const fontDataPath = path.resolve(require.resolve('pdfjs-dist'), '../../standard_fonts')
   const pdfDocument = await pdfjs.getDocument(
     {
       data: docOptions,


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

When parsing a document that attempts to reach a new font file from the standard font path, it throws a warning:
```
Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException:  The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
```
This warning is thrown for every document that is being parsed with every font file it cannot use so when executed with a `--recursive` parameter this can flood the terminal. For e.g.:

```
Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
Warning: fetchStandardFontData: failed to fetch file "FoxitSansBold.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
Warning: fetchStandardFontData: failed to fetch file "FoxitSansItalic.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
Warning: fetchStandardFontData: failed to fetch file "FoxitSansBoldItalic.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
```

## Solution

_How did you solve the problem?_

**Bug Fixes**:

This automatically passes in the standardFontDataUrl path with the default path of the pdfjs-dist package. A thought had occurred to pass this in via argument but it's already verbose enough and this path should be standard across most machines using pdf2md.

## Before & After Screenshots

**BEFORE**:
Following console warning is thrown
```Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".```

**AFTER**:
No more console warnings