### PR TITLE
fix `parse()` arguments to match the documented types

### DIFF
--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -5,7 +5,6 @@ pdfjs.GlobalWorkerOptions.workerSrc = `pdfjs-dist/legacy/build/pdf.worker`
 const { findPageNumbers, findFirstPage, removePageNumber } = require('../../lib/util/page-number-functions')
 const TextItem = require('../models/TextItem')
 const Page = require('../models/Page')
-const { isTypedArray } = require('util/types')
 
 const NO_OP = () => {}
 
@@ -20,7 +19,7 @@ exports.parse = async function parse (docOptions, callbacks) {
   const fontDataPath = path.join( path.resolve(require.resolve('pdfjs-dist'), '../../standard_fonts'), '/')
   if (typeof docOptions === "string" || docOptions instanceof URL) {
     docOptions = { url: docOptions };
-  } else if (docOptions instanceof ArrayBuffer || isTypedArray(docOptions)) {
+  } else if (docOptions instanceof ArrayBuffer || ArrayBuffer.isView(docOptions)) {
     docOptions = { data: docOptions };
   }
   const pdfDocument = await pdfjs.getDocument(

--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -5,6 +5,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = `pdfjs-dist/legacy/build/pdf.worker`
 const { findPageNumbers, findFirstPage, removePageNumber } = require('../../lib/util/page-number-functions')
 const TextItem = require('../models/TextItem')
 const Page = require('../models/Page')
+const { isTypedArray } = require('util/types')
 
 const NO_OP = () => {}
 
@@ -17,9 +18,14 @@ exports.parse = async function parse (docOptions, callbacks) {
     ...(callbacks || {}),
   }
   const fontDataPath = path.join( path.resolve(require.resolve('pdfjs-dist'), '../../standard_fonts'), '/')
+  if (typeof docOptions === "string" || docOptions instanceof URL) {
+    docOptions = { url: docOptions };
+  } else if (docOptions instanceof ArrayBuffer || isTypedArray(docOptions)) {
+    docOptions = { data: docOptions };
+  }
   const pdfDocument = await pdfjs.getDocument(
     {
-      data: docOptions,
+      ...docOptions,
       standardFontDataUrl: fontDataPath
     }).promise
   const metadata = await pdfDocument.getMetadata()


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

The `pdf2md` say it will receive the following type:
```
@param {string|TypedArray|DocumentInitParameters|PDFDataRangeTransport} pdfBuffer
 * Passed to `pdfjs.getDocument()` to read a PDF document for conversion
 ```

However, it only works with `BinaryData` type.

## Solution

_How did you solve the problem?_

I add a type check and make the first argument convert to `docOptions` depends on the type given:

```js
if (typeof docOptions === "string" || docOptions instanceof URL) {
  docOptions = { url: docOptions };
} else if (docOptions instanceof ArrayBuffer || ArrayBuffer.isView(docOptions)) {
  docOptions = { data: docOptions };
}
```

This should match the docs of `pdfjs`:
https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib.html