### PR TITLE
Add TypeScript Declaration File.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,5 +25,6 @@
     "flowtype": {
       "onlyFilesWithFlowAnnotation": true
     }
-  }
+  },
+  "ignorePatterns": ["node_modules/", "**/*.ts"]
 }

--- a/lib/pdf2md.js
+++ b/lib/pdf2md.js
@@ -16,7 +16,7 @@ if (typeof document === 'undefined') {
  * @param {Function} [callbacks.fontParsed]
  * @param {Function} [callbacks.documentParsed]
  *
- * @returns {string} The Markdown text
+ * @returns {Promise<string>} The Markdown text
  */
 module.exports = async function (pdfBuffer, callbacks) {
   const result = await parse(pdfBuffer, callbacks)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.27",
   "description": "A PDF to Markdown Converter",
   "main": "lib/pdf2md.js",
+  "types": "types/pdf2md.d.ts",
   "bin": {
     "pdf2md": "lib/pdf2md-cli.js"
   },

--- a/types/pdf2md.d.ts
+++ b/types/pdf2md.d.ts
@@ -1,0 +1,49 @@
+import type {
+  PDFDocumentProxy,
+  DocumentInitParameters,
+  TypedArray,
+  TextItem,
+} from "pdfjs-dist/types/display/api";
+
+interface Page {
+  index: number;
+  items: TextItem[];
+}
+interface Font {
+  ids: Set<string>;
+  map: Map<string, any>;
+}
+interface Metadata {
+  info: Object;
+  metadata: {
+    parsedData: any;
+    rawData: any;
+    getRaw: () => any;
+    get: (name: any) => any;
+    getAll: () => any;
+    has: (name: any) => any;
+  };
+}
+
+/**
+ * Converts a PDF file to a Markdown string.
+ *
+ * @param {string | URL | TypedArray | ArrayBuffer | DocumentInitParameters} pdfBuffer - The PDF file to convert.
+ * @param {object} callbacks - Optional callbacks for various events during the conversion process.
+ * @param {function} callbacks.metadataParsed - Callback for when metadata is parsed.
+ * @param {function} callbacks.pageParsed - Callback for when each page is parsed.
+ * @param {function} callbacks.fontParsed - Callback for when a font is parsed.
+ * @param {function} callbacks.documentParsed - Callback for when the entire document is parsed.
+ * @return {Promise<string>} A promise that resolves to the converted Markdown string.
+ */
+declare function pdf2md(
+  pdfBuffer: string | URL | TypedArray | ArrayBuffer | DocumentInitParameters,
+  callbacks?: {
+    metadataParsed?: (metadata: Metadata) => void;
+    pageParsed?: (pages: Page[]) => void;
+    fontParsed?: (font: Font) => void;
+    documentParsed?: (document: PDFDocumentProxy, pages: Page[]) => void;
+  }
+): Promise<string>;
+
+export default pdf2md;


### PR DESCRIPTION
## Problem

Add TypeScript type definitions for the pdf2md library to improve integration with TypeScript projects.

## Solution

Wrote a types/pdf2md.d.ts type definition file with declarations for the pdf2md interface.

**Features**:

- Added a complete `types/pdf2md.d.ts` type definition file declaring the externally exposed interfaces of pdf2md

**Improvements**: 

- Define the function type of `pdf2md()` in `types/pdf2md.d.ts` to document details of the interfaces
