### PR TITLE
fix: include "/types" in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "/lib",
-    "/test"
+    "/test",
+    "/types"
   ],
   "scripts": {
     "lint": "eslint lib --cache",


### PR DESCRIPTION
## Problem

npm package should includes "/types/**" files

resolves https://github.com/opengovsg/pdf2md/pull/78#issuecomment-1982217310

## Solution

modify package.json