### PR TITLE
add page break

### DIFF
--- a/lib/pdf2md.js
+++ b/lib/pdf2md.js
@@ -23,7 +23,7 @@ module.exports = async function (pdfBuffer, callbacks) {
   const parseResult = transform(pages, transformations)
   const text = parseResult.pages
     .map(page => page.items.join('\n') + '\n')
-    .join('')
+    .join('<!-- PAGE_BREAK -->\n')
   try {
     return text
   } finally {


### PR DESCRIPTION
## Problem

Being able to split by page for later page identification or any source tracking (in use of the MD file in RAG etc)

## Solution

Simply change from " " concatination/join to using <!-- PAGE_BREAK --> .. which is compatible with markdown syntax
